### PR TITLE
add dockerignore to protect secrets and reduce docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+db/
+.git/*
+**/_*.ts
+configs.ts
+fileloader.ts
+.env


### PR DESCRIPTION
This way locally configured config.ts, local db won't be copied inside the container.
This also prevent .git to be copied inside the container, reducing the global image size